### PR TITLE
Remove @Override annotation in AppInitializer#onStartup

### DIFF
--- a/01-hello-world/src/main/java/FreeMarkerTutorials/AppInitializer.java
+++ b/01-hello-world/src/main/java/FreeMarkerTutorials/AppInitializer.java
@@ -11,7 +11,7 @@ import org.springframework.web.context.support.AnnotationConfigWebApplicationCon
 import org.springframework.web.servlet.DispatcherServlet;
 
 public class AppInitializer implements WebApplicationInitializer {
-    @Override
+    
     public void onStartup(ServletContext servletContext) throws ServletException {
         WebApplicationContext context = getContext();
         servletContext.addListener(new ContextLoaderListener(context));


### PR DESCRIPTION
Eclipse IDE marks the Override annotation in AppInitializer as an error, as the class implements onStartup rather than overriding the method from a superclass.

![image](https://cloud.githubusercontent.com/assets/742368/17132400/7f2c2cb0-5319-11e6-8021-a947df3991d6.png)
